### PR TITLE
Make boundary checks in regex match stronger

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,12 @@
 {{$NEXT}}
 
+- The word boundary check supposedly added in 1.67 didn't really work
+  properly, and still matched too much. For example, the pattern "%d-%m-%y"
+  would match "2016-11-30" and turn it into November 16, 2030. This also had
+  problems at the end of strings, so that the same pattern would improperly
+  match "30-11-2016" as November 30, 2020. Reported by Erik Huelsmann. GitHub
+  #11.
+
 - Added docs for several formats which had long been supported but not
   documented. These are %P, %c, %x, and %X. Reported by Alexander
   Hartmaier. GH #10.

--- a/lib/DateTime/Format/Strptime.pm
+++ b/lib/DateTime/Format/Strptime.pm
@@ -341,8 +341,8 @@ sub _build_parser {
 }
 
 {
-    my $d                 = qr/(?:[0-9])/;
-    my $one_or_two_digits = qr/[0-9 ]?$d/;
+    my $digit             = qr/(?:[0-9])/;
+    my $one_or_two_digits = qr/[0-9 ]?$digit/;
 
     # These patterns are all locale-independent. There are a few that depend
     # on the locale, and must be re-calculated for each new parser object.
@@ -363,7 +363,7 @@ sub _build_parser {
             field => 'iso_week_year_100',
         },
         G => {
-            regex => qr/$d{4}/,
+            regex => qr/$digit{4}/,
             field => 'iso_week_year',
         },
         H => {
@@ -375,7 +375,7 @@ sub _build_parser {
             field => 'hour_12',
         },
         j => {
-            regex => qr/$d{1,3}/,
+            regex => qr/$digit{1,3}/,
             field => 'day_of_year',
         },
         m => {
@@ -394,7 +394,7 @@ sub _build_parser {
             field => 'time_zone_name',
         },
         s => {
-            regex => qr/$d+/,
+            regex => qr/$digit+/,
             field => 'epoch',
         },
         S => {
@@ -422,11 +422,11 @@ sub _build_parser {
             field => 'year_100',
         },
         Y => {
-            regex => qr/$d{4}/,
+            regex => qr/$digit{4}/,
             field => 'year',
         },
         z => {
-            regex => qr/[+-]$d{4}/,
+            regex => qr/[+-]$digit{4}/,
             field => 'time_zone_offset',
         },
         Z => {

--- a/lib/DateTime/Format/Strptime.pm
+++ b/lib/DateTime/Format/Strptime.pm
@@ -335,7 +335,7 @@ sub _build_parser {
     }
 
     return {
-        regex  => qr/(?:\A\s|\b)*$regex/,
+        regex  => qr/(?:\A|\b)$regex(\b|\Z)/,
         fields => \@fields,
     };
 }

--- a/t/errors.t
+++ b/t/errors.t
@@ -246,6 +246,18 @@ subtest(
             input   => 'Wed Feb 29 12:02:28 2013',
             error   => qr{\QParsed values did not produce a valid date},
         },
+        {
+            name    => 'Failed word boundary check at beginning - GitHub #11',
+            pattern => '%d-%m-%y',
+            input   => '2016-11-30',
+            error   => qr{\QYour datetime does not match your pattern},
+        },
+        {
+            name    => 'Failed word boundary check at end',
+            pattern => '%d-%m-%y',
+            input   => '30-11-2016',
+            error   => qr{\QYour datetime does not match your pattern},
+        },
     );
 
     for my $test (@tests) {


### PR DESCRIPTION
This fixes some bugs (which are tested in the tests) where patterns matched things in weird and confusing ways.