### PR TITLE
Accept more representation in %z conversion specifier

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+- Altered the conversion specifier %z to accept ±HH, ±HHMM, ±HH:MM and Z.
+  Previously only ±HHMM where accepted. PR from Christian Hansen, GitHub #13.
+
+
 1.69     2016-12-04 (TRIAL RELEASE)
 
 - The word boundary check supposedly added in 1.67 didn't really work

--- a/lib/DateTime/Format/Strptime.pm
+++ b/lib/DateTime/Format/Strptime.pm
@@ -426,7 +426,7 @@ sub _build_parser {
             field => 'year',
         },
         z => {
-            regex => qr/[+-]$digit{4}/,
+            regex => qr/(?:Z|[+-][0-9]{2}(?:[:]?[0-9]{2})?)/,
             field => 'time_zone_offset',
         },
         Z => {
@@ -607,8 +607,19 @@ sub _token_re_for {
         }
 
         if ( $args->{time_zone_offset} ) {
+            my ( $sign, $hours, $minutes ) = ( '+', 0, 0 );
+
+            if ( $args->{time_zone_offset} ne 'Z' ) {
+                $args->{time_zone_offset} =~ s/://;
+                ( $sign, $hours, $minutes ) = unpack 'A(A2)*',
+                    $args->{time_zone_offset};
+                $minutes = 0 unless defined $minutes;
+            }
+
             $args->{time_zone} = DateTime::TimeZone->new(
-                name => $args->{time_zone_offset} );
+                name => sprintf '%s%.2d:%.2d',
+                $sign, $hours, $minutes
+            );
         }
 
         if ( defined $args->{time_zone_abbreviation} ) {

--- a/lib/DateTime/Format/Strptime.pm
+++ b/lib/DateTime/Format/Strptime.pm
@@ -607,19 +607,16 @@ sub _token_re_for {
         }
 
         if ( $args->{time_zone_offset} ) {
-            my ( $sign, $hours, $minutes ) = ( '+', 0, 0 );
+            my $offset = $args->{time_zone_offset};
 
-            if ( $args->{time_zone_offset} ne 'Z' ) {
-                $args->{time_zone_offset} =~ s/://;
-                ( $sign, $hours, $minutes ) = unpack 'A(A2)*',
-                    $args->{time_zone_offset};
-                $minutes = 0 unless defined $minutes;
+            if ( $offset eq 'Z' ) {
+                $offset = '+0000';
+            }
+            elsif ( $offset =~ /^[+-][0-9]{2}$/ ) {
+                $offset .= '00';
             }
 
-            $args->{time_zone} = DateTime::TimeZone->new(
-                name => sprintf '%s%.2d:%.2d',
-                $sign, $hours, $minutes
-            );
+            $args->{time_zone} = DateTime::TimeZone->new( name => $offset );
         }
 
         if ( defined $args->{time_zone_abbreviation} ) {

--- a/t/basic.t
+++ b/t/basic.t
@@ -226,13 +226,66 @@ minute     => 45
 second     => 56
 nanosecond => 543000000
 
-[time zone as numeric offset]
+[time zone as numeric offset Z]
 %H:%M:%S %z
-23:45:56 +1000
+23:45:56 Z
+skip round trip
+hour       => 23
+minute     => 45
+second     => 56
+offset     => 0
+
+[time zone as numeric offset +HH]
+%H:%M:%S %z
+23:45:56 +10
+skip round trip
 hour       => 23
 minute     => 45
 second     => 56
 offset     => 36000
+
+[time zone as numeric offset -HH]
+%H:%M:%S %z
+23:45:56 -10
+skip round trip
+hour       => 23
+minute     => 45
+second     => 56
+offset     => -36000
+
+[time zone as numeric offset +HHMM]
+%H:%M:%S %z
+23:45:56 +1030
+hour       => 23
+minute     => 45
+second     => 56
+offset     => 37800
+
+[time zone as numeric offset -HHMM]
+%H:%M:%S %z
+23:45:56 -1030
+hour       => 23
+minute     => 45
+second     => 56
+offset     => -37800
+
+[time zone as numeric offset +HH:MM]
+%H:%M:%S %z
+23:45:56 +10:30
+skip round trip
+hour       => 23
+minute     => 45
+second     => 56
+offset     => 37800
+
+[time zone as numeric offset -HH:MM]
+%H:%M:%S %z
+23:45:56 -10:30
+skip round trip
+hour       => 23
+minute     => 45
+second     => 56
+offset     => -37800
 
 [time zone as abbreviation]
 %H:%M:%S %Z

--- a/t/basic.t
+++ b/t/basic.t
@@ -226,7 +226,7 @@ minute     => 45
 second     => 56
 nanosecond => 543000000
 
-[time zone as numeric offset Z]
+[time zone as letter Z]
 %H:%M:%S %z
 23:45:56 Z
 skip round trip


### PR DESCRIPTION
 The %z conversion specifier accepts:

   ±HH
   ±HHMM
   ±HH:MM
   Z