### PR TITLE
Fixed try-catch syntax according to Try::Tiny

### DIFF
--- a/lib/DateTime/Format/Strptime.pm
+++ b/lib/DateTime/Format/Strptime.pm
@@ -885,7 +885,7 @@ sub pattern {
         }
         catch {
             $self->_our_carp($_);
-        }
+        };
 
         return unless $new;
 
@@ -911,7 +911,7 @@ sub locale {
         }
         catch {
             $self->_our_carp($_);
-        }
+        };
 
         return unless $new;
 
@@ -939,7 +939,7 @@ sub time_zone {
         }
         catch {
             $self->_our_carp($_);
-        }
+        };
 
         return unless $new;
 


### PR DESCRIPTION
Existing approach doesn't work. Without semi it's:
```
try {...} catch( {...}, return)
```